### PR TITLE
Substitution ciphers

### DIFF
--- a/src/main/java/io/induct/algae/substitution/AbstractSubstitutionCipher.java
+++ b/src/main/java/io/induct/algae/substitution/AbstractSubstitutionCipher.java
@@ -1,0 +1,22 @@
+package io.induct.algae.substitution;
+
+import com.google.common.base.Preconditions;
+
+/**
+ * @since 24.1.2015
+ */
+abstract class AbstractSubstitutionCipher implements SubstitutionCipher {
+
+    @Override
+    public byte[] substitute(byte[] bytes) {
+        Preconditions.checkNotNull(bytes, "Cannot substitute contents of null array");
+
+        byte[] substituted = new byte[bytes.length];
+        for (int i = 0; i < substituted.length; i++) {
+            substituted[i] = lookup(bytes[i]);
+        }
+        return substituted;
+    }
+
+    protected abstract byte lookup(byte b);
+}

--- a/src/main/java/io/induct/algae/substitution/AtbashSubstitutionCipher.java
+++ b/src/main/java/io/induct/algae/substitution/AtbashSubstitutionCipher.java
@@ -9,7 +9,7 @@ import java.util.Arrays;
  * @since 24.1.2015
  * @see <a href="http://en.wikipedia.org/wiki/Atbash">Atbash cipher</a>
  */
-public class AtbashSubstitutionCipher {
+public class AtbashSubstitutionCipher extends AbstractSubstitutionCipher implements SubstitutionCipher {
 
     private final static byte UNKNOWN_BYTE = -1;
 
@@ -28,17 +28,10 @@ public class AtbashSubstitutionCipher {
         }
     }
 
-    public byte[] substitute(byte[] bytes) {
-        Preconditions.checkNotNull(bytes, "Cannot substitute contents of null array");
-
-        byte[] substituted = new byte[bytes.length];
-        for (int i = 0; i < bytes.length; i++) {
-            byte b = bytes[i];
-            byte sb = substitutions[b];
-            Preconditions.checkArgument(sb >= 0, "No known substitution for byte " + b);
-            substituted[i] = sb;
-        }
-
-        return substituted;
+    @Override
+    protected byte lookup(byte b) {
+        byte sb = substitutions[b];
+        Preconditions.checkArgument(sb >= 0, "No known substitution for byte " + b);
+        return sb;
     }
 }

--- a/src/main/java/io/induct/algae/substitution/AtbashSubstitutionCipher.java
+++ b/src/main/java/io/induct/algae/substitution/AtbashSubstitutionCipher.java
@@ -1,0 +1,44 @@
+package io.induct.algae.substitution;
+
+import com.google.common.base.Preconditions;
+
+import java.util.Arrays;
+
+/**
+ * @author Esko Suomi <suomi.esko@gmail.com>
+ * @since 24.1.2015
+ * @see <a href="http://en.wikipedia.org/wiki/Atbash">Atbash cipher</a>
+ */
+public class AtbashSubstitutionCipher {
+
+    private final static byte UNKNOWN_BYTE = -1;
+
+    private final byte[] substitutions;
+
+    public AtbashSubstitutionCipher(byte[] key) {
+        substitutions = new byte[Byte.MAX_VALUE];
+        Arrays.fill(substitutions, UNKNOWN_BYTE);
+        for (int head = 0; head < key.length; head++) {
+            byte headValue = key[head];
+            Preconditions.checkArgument(headValue >= 0, "Cannot use negative byte value '" + headValue + "' for substitution");
+            int tail = key.length - 1 - head;
+            byte tailValue = key[tail];
+            Preconditions.checkArgument(tailValue >= 0, "Cannot use negative byte value '" + tailValue + "' for substitution");
+            substitutions[headValue] = tailValue;
+        }
+    }
+
+    public byte[] substitute(byte[] bytes) {
+        Preconditions.checkNotNull(bytes, "Cannot substitute contents of null array");
+
+        byte[] substituted = new byte[bytes.length];
+        for (int i = 0; i < bytes.length; i++) {
+            byte b = bytes[i];
+            byte sb = substitutions[b];
+            Preconditions.checkArgument(sb >= 0, "No known substitution for byte " + b);
+            substituted[i] = sb;
+        }
+
+        return substituted;
+    }
+}

--- a/src/main/java/io/induct/algae/substitution/Rot13SubstitutionCipher.java
+++ b/src/main/java/io/induct/algae/substitution/Rot13SubstitutionCipher.java
@@ -1,0 +1,35 @@
+package io.induct.algae.substitution;
+
+/**
+ * ROT13 substitution rules:
+ *  - Alphabetics are shifted onwards 13 characters
+ *  - Upper/lowercasing is kept accordingly
+ *  - Punctuation and such is kept as is
+ *
+ * As this is ROT13 it only works with the Latin 26 character alphabet.
+ *
+ * Why? Because the world needs this.
+ *
+ * @since 24.1.2015
+ * @see <a href="http://en.wikipedia.org/wiki/ROT13">ROT13</a>
+ */
+public final class Rot13SubstitutionCipher extends AbstractSubstitutionCipher implements SubstitutionCipher {
+
+    public static final Rot13SubstitutionCipher INSTANCE = new Rot13SubstitutionCipher();
+
+    private Rot13SubstitutionCipher() {}
+
+    @Override
+    protected byte lookup(byte b) {
+
+        if (b > 96 && b < 123) {
+            // lowercase substitution
+            return (byte) ((b < 109) ? b + 13 : b - 13);
+        } else if (b > 64 && b < 91) {
+            // uppercase substitution
+            return (byte) ((b < 78) ? b + 13 : b - 13);
+        } else {
+            return b;
+        }
+    }
+}

--- a/src/main/java/io/induct/algae/substitution/SubstitutionCipher.java
+++ b/src/main/java/io/induct/algae/substitution/SubstitutionCipher.java
@@ -1,0 +1,11 @@
+package io.induct.algae.substitution;
+
+/**
+ * @author Esko Suomi <suomi.esko@gmail.com>
+ * @since 24.1.2015
+ */
+public interface SubstitutionCipher {
+
+    byte[] substitute(byte[] bytes);
+
+}

--- a/src/main/java/io/induct/util/MoreArrays.java
+++ b/src/main/java/io/induct/util/MoreArrays.java
@@ -1,0 +1,54 @@
+package io.induct.util;
+
+import java.util.Arrays;
+import java.util.function.Supplier;
+
+/**
+ * @author Esko Suomi <suomi.esko@gmail.com>
+ * @since 24.1.2015
+ */
+public class MoreArrays {
+
+    /**
+     * Pivot given table by its axii, eg. turn
+     * <pre><code>
+     *[[a,b,c]
+     * [d,e,f]]</code></pre>
+     * to
+     * <pre><code>
+     *[[a,d],
+     * [b,e],
+     * [c,f]]
+     * </code></pre>
+     *
+     * @param bytes
+     * @return
+     */
+    public static byte[][] pivot(byte[][] bytes) {
+        int maxWidth = bytes[0].length;
+        int maxHeight = bytes.length;
+        byte[][] pivot = new byte[maxWidth][];
+        MoreArrays.fill(pivot, () -> new byte[maxHeight]);
+
+        for (int x = 0; x < maxHeight; x++) {
+            for (int y = 0; y < maxWidth; y++) {
+                byte b = bytes[x][y];
+                pivot[y][x] = b;
+            }
+        }
+        return pivot;
+    }
+
+    /**
+     * Fill array entries with supplier provided values. Unlike {@link Arrays#fill(Object[], Object)} this causes unique
+     * values to be used for each cell
+     *
+     * @param arr Array to fill
+     * @param supplier Supplier for fill value
+     */
+    public static void fill(Object[] arr, Supplier<?> supplier) {
+        for (int i = 0; i < arr.length; i++) {
+            arr[i] = supplier.get();
+        }
+    }
+}

--- a/src/main/java/io/induct/util/MoreStrings.java
+++ b/src/main/java/io/induct/util/MoreStrings.java
@@ -1,0 +1,22 @@
+package io.induct.util;
+
+import com.google.common.base.Preconditions;
+
+/**
+ * Things not available in {@link com.google.common.base.Strings}
+ *
+ * @since 24.1.2015
+ */
+public class MoreStrings {
+    public static String reverse(String s) {
+        Preconditions.checkNotNull(s, "null String is irreversible");
+        if (s.length() > 0) {
+            return new StringBuilder(s.length())
+                    .append(s)
+                    .reverse()
+                    .toString();
+        } else {
+            return s;
+        }
+    }
+}

--- a/src/test/java/io/induct/algae/substitution/AtbashSubstitutionCipherTest.java
+++ b/src/test/java/io/induct/algae/substitution/AtbashSubstitutionCipherTest.java
@@ -1,0 +1,25 @@
+package io.induct.algae.substitution;
+
+import io.induct.util.MoreStrings;
+import org.junit.Test;
+
+import java.util.Arrays;
+
+import static org.junit.Assert.*;
+
+public class AtbashSubstitutionCipherTest {
+
+    @Test
+    public void substitutesCharacterPairsCorrectly() throws Exception {
+        String key = "abcdefghijklmnoprstuvwxyz";
+        AtbashSubstitutionCipher atbash = new AtbashSubstitutionCipher(key.getBytes());
+        byte[] substituted = atbash.substitute(key.getBytes());
+        assertTrue(Arrays.equals(substituted, MoreStrings.reverse(key).getBytes()));
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void tryingToSubstituteUnknownCharacterWillThrowAnException() throws Exception {
+        AtbashSubstitutionCipher atbash = new AtbashSubstitutionCipher("whatever".getBytes());
+        atbash.substitute("0".getBytes());
+    }
+}

--- a/src/test/java/io/induct/algae/substitution/LookupRot13SubstitutionCipher.java
+++ b/src/test/java/io/induct/algae/substitution/LookupRot13SubstitutionCipher.java
@@ -1,0 +1,33 @@
+package io.induct.algae.substitution;
+
+import io.induct.util.MoreArrays;
+
+/**
+ * Alternate lookup table based implementation for ROT13 but slightly slower than {@link io.induct.algae.substitution.Rot13SubstitutionCipher}
+ *
+ * @since 24.1.2015
+ */
+public final class LookupRot13SubstitutionCipher extends AbstractSubstitutionCipher implements SubstitutionCipher {
+
+    public static final LookupRot13SubstitutionCipher INSTANCE = new LookupRot13SubstitutionCipher();
+
+    private LookupRot13SubstitutionCipher() {}
+
+    private final static byte[][] LOOKUP = MoreArrays.pivot(new byte[][]{
+            "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz".getBytes(),
+            "NOPQRSTUVWXYZABCDEFGHIJKLMnopqrstuvwxyzabcdefghijklm".getBytes()
+    });
+
+    @Override
+    protected byte lookup(byte b) {
+        if ((b > 96 && b < 123)) {
+            // lowercase substitution
+            return LOOKUP[b - 71][1];
+        } else if ((b > 64 && b < 91)) {
+            // uppercase substitution
+            return LOOKUP[b - 65][1];
+        } else {
+            return b;
+        }
+    }
+}

--- a/src/test/java/io/induct/algae/substitution/Rot13SubstitutionCipherTest.java
+++ b/src/test/java/io/induct/algae/substitution/Rot13SubstitutionCipherTest.java
@@ -1,0 +1,51 @@
+package io.induct.algae.substitution;
+
+import com.google.common.base.Stopwatch;
+import com.google.common.collect.Iterables;
+import org.junit.Ignore;
+import org.junit.Test;
+
+import java.util.Collections;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
+
+import static org.junit.Assert.*;
+
+public class Rot13SubstitutionCipherTest {
+
+    @Test
+    @Ignore
+    public void testPerf() throws Exception {
+        List<Long> runTimes = new LinkedList<>();
+
+        for (int i = 0; i < 10; i++) {
+            Stopwatch loopTime = Stopwatch.createStarted();
+            for (int j = 0; j < 1000000; j++) {
+                substitutesExampleFromWikipediaCorrectly();
+            }
+            loopTime.stop();
+            runTimes.add(loopTime.elapsed(TimeUnit.MILLISECONDS));
+        }
+
+        Collections.sort(runTimes);
+        System.out.println("Fastest: " + runTimes.get(0) + "ms");
+        System.out.println("Slowest: " + runTimes.get(9) + "ms");
+
+        long sum = runTimes.stream().reduce((acc, x) -> acc + x).get();
+        System.out.println("Average: " + (((double) sum + 0.5) / 10)  + "ms");
+    }
+
+    @Test
+    public void substitutesExampleFromWikipediaCorrectly() throws Exception {
+        LookupRot13SubstitutionCipher rot13 = LookupRot13SubstitutionCipher.INSTANCE;
+        assertSubstitution(rot13, "Why did the chicken cross the road?", "Jul qvq gur puvpxra pebff gur ebnq?");
+        assertSubstitution(rot13, "To get to the other side!", "Gb trg gb gur bgure fvqr!");
+    }
+
+    private static void assertSubstitution(SubstitutionCipher cipher, String expected, String actual) {
+        String substituted = new String(cipher.substitute(actual.getBytes()));
+        assertEquals(expected, substituted);
+    }
+}

--- a/src/test/java/io/induct/util/MoreArraysTest.java
+++ b/src/test/java/io/induct/util/MoreArraysTest.java
@@ -1,0 +1,25 @@
+package io.induct.util;
+
+import org.junit.Test;
+
+import java.util.Arrays;
+
+import static org.junit.Assert.*;
+
+public class MoreArraysTest {
+
+    @Test
+    public void pivotsGivenTwoDimensionalArray() throws Exception {
+        assertTrue(
+                Arrays.deepEquals(MoreArrays.pivot(new byte[][] {
+                        new byte[] { 'a', 'b', 'c' },
+                        new byte[] { 'd', 'e', 'f' },
+                }),
+                new byte[][] {
+                        new byte[] { 'a', 'd' },
+                        new byte[] { 'b', 'e' },
+                        new byte[] { 'c', 'f' }
+                })
+        );
+    }
+}

--- a/src/test/java/io/induct/util/MoreStringsTest.java
+++ b/src/test/java/io/induct/util/MoreStringsTest.java
@@ -1,0 +1,15 @@
+package io.induct.util;
+
+import org.junit.Test;
+
+import static io.induct.util.MoreStrings.reverse;
+import static org.junit.Assert.*;
+
+public class MoreStringsTest {
+
+    @Test
+    public void reverseWorks() throws Exception {
+        // generally tests like this are a bit redundant...
+        assertEquals("cba", reverse("abc"));
+    }
+}


### PR DESCRIPTION
Implemented [Atbash](http://en.wikipedia.org/wiki/Atbash) and [ROT13](http://en.wikipedia.org/wiki/ROT13) substitution ciphers.
